### PR TITLE
feature : header 컴포넌트 작성

### DIFF
--- a/client/src/components/commons/Button/Button.stories.tsx
+++ b/client/src/components/commons/Button/Button.stories.tsx
@@ -59,7 +59,7 @@ export const all = () => (
       취소
     </Button>
     <br />
-    <Button pattern={'roundModal'} bright={'dark'}>
+    <Button pattern={'roundModalSmall'} bright={'dark'}>
       확인
     </Button>
     <br />

--- a/client/src/containers/commons/Header/Header.stories.tsx
+++ b/client/src/containers/commons/Header/Header.stories.tsx
@@ -1,0 +1,19 @@
+import Header from './Header';
+
+export default {
+  title: 'Container/Header',
+  component: Header,
+};
+
+export const all = () => (
+  <>
+    <div>모바일</div>
+    <Header device={'mobile'} login={false} />
+    <br />
+    <br />
+    <div>데스크탑</div>
+    <Header device={'desktop'} login={false} />
+    <br />
+    <Header device={'desktop'} login={true} />
+  </>
+);

--- a/client/src/containers/commons/Header/Header.styles.ts
+++ b/client/src/containers/commons/Header/Header.styles.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+export const Layout = styled.header`
+  width: 360px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Title = styled.h1``;
+
+export const IconBlock = styled.div`
+  display: flex;
+  margin: 0px 0px 0px auto;
+  svg {
+    margin: 0px 10px 0px 0px;
+  }
+`;
+
+export const DesktopLayout = styled.header`
+  width: 1200px;
+  display: flex;
+  align-items: center;
+`;
+
+export const NavBlock = styled.nav`
+  display: flex;
+  margin: 0px 0px 0px 20px;
+  div {
+    margin: 0px 0px 0px 10px;
+  }
+`;
+
+export const RightBlock = styled.div`
+  display: flex;
+  margin: 0px 0px 0px auto;
+  svg {
+    margin: 0px 10px 0px 0px;
+  }
+  button {
+    margin: 0px 10px 0px 0px;
+  }
+`;

--- a/client/src/containers/commons/Header/Header.tsx
+++ b/client/src/containers/commons/Header/Header.tsx
@@ -1,0 +1,63 @@
+import Icon from '../../../components/foundations/Icon/Icon';
+import {
+  DesktopLayout,
+  IconBlock,
+  Layout,
+  NavBlock,
+  RightBlock,
+  Title,
+} from './Header.styles';
+import React from 'react';
+import Button from '../../../components/commons/Button';
+
+export interface HeaderProps {
+  device: string;
+  login: boolean;
+}
+
+const Header = ({...props}: HeaderProps) => {
+  if (props.device === 'mobile') {
+    return (
+      <Layout>
+        <Title>Learing chain</Title>
+        <IconBlock>
+          <Icon icon={'search'} aria-hidden />
+          <Icon icon={'notification'} aria-hidden />
+        </IconBlock>
+      </Layout>
+    );
+  } else {
+    return (
+      <DesktopLayout>
+        <Title>Learing chain</Title>
+        <NavBlock>
+          <div>콘텐츠</div>
+          <div>스터디</div>
+          <div>로드맵</div>
+        </NavBlock>
+        {props.login ? (
+          <RightBlock>
+            <Icon icon={'search'} aria-hidden />
+            <Icon icon={'notification'} aria-hidden />
+            <Icon icon={'my'} aria-hidden />
+            <Button pattern={'roundModalSmall'} bright={'light'}>
+              작성하기
+            </Button>
+          </RightBlock>
+        ) : (
+          <RightBlock>
+            <Button pattern={'roundModalSmall'} bright={'light'}>
+              로그인
+            </Button>
+            <br />
+            <Button pattern={'roundModalSmall'} bright={'dark'}>
+              회원가입
+            </Button>
+          </RightBlock>
+        )}
+      </DesktopLayout>
+    );
+  }
+};
+
+export default Header;

--- a/client/src/containers/commons/Header/index.ts
+++ b/client/src/containers/commons/Header/index.ts
@@ -1,1 +1,1 @@
-export {}
+export {default} from './Header';


### PR DESCRIPTION
closes #73 

## 작업 내용
-header 컴포넌트 작성
-header 스토리 작성(굳이 필요하지는 않은것 같습니다. 컴포넌트 확인용도입니다. 이후 삭제하면 될것 같습니다.)

## 주의 사항
-모바일, 데스크탑 로그인, 데스크탑 비로그인 이렇게 세가지 종류가 존재하여, 세가지케이스를 만들었습니다. 헤더 내부에서 해당 상태를 판별하는것이 좋을것 같지만, 반응형을 처리하는 방식과 로그인 처리하는 방식이 결정되지 않아서 일단 내부에서 받게 만들었습니다.
-버튼 부분에 오타가 있어 수정사항이 있습니다.