### PR TITLE
design: SidebarItem에 Checkbox 추가

### DIFF
--- a/client/src/components/commons/Checkbox/index.ts
+++ b/client/src/components/commons/Checkbox/index.ts
@@ -1,1 +1,1 @@
-export {default} from './Checkbox';
+export {default as Checkbox} from './Checkbox';

--- a/client/src/components/commons/SideBarItem/SideBarItem.tsx
+++ b/client/src/components/commons/SideBarItem/SideBarItem.tsx
@@ -1,4 +1,5 @@
 import {Layout, TitleBox, Title, Content} from './SideBarItem.styles';
+import {Checkbox} from '../Checkbox';
 
 export interface SideBarItemProps {
   theme?: string;
@@ -8,11 +9,13 @@ export interface SideBarItemProps {
   pattern?: string;
 }
 
+// checkbox랑 라벨링 필요.
 const SideBarItem = ({title, description, isLoading, ...props}: SideBarItemProps) => {
   const text = isLoading ? '' : title;
   const desc = isLoading ? '' : description;
   return (
     <Layout {...props}>
+      <Checkbox />
       <TitleBox isLoading={isLoading} {...props}>
         <Title>{text}</Title>
       </TitleBox>


### PR DESCRIPTION
closes #98

## 작업 내용
- 단순 ui만 추가

## 주의 사항
- SideBarItem의 Checkbox 디자인이 직사각형박스에서 원형박스로 바뀜에 따라 추가 필요.
- Checkbox의 labeling은 label text를 넘기게 되어있는데 SidebarItem에서 Text를 따로 관리하고 있음. 추후 디자인에 따라 둘 중 하나 불필요.